### PR TITLE
Remove stray console.log

### DIFF
--- a/watch.js
+++ b/watch.js
@@ -115,7 +115,7 @@
 
       // Create new Mutation Observer
       var observer = new MutationObserver(function (mutations) {
-        console.log(mutations);
+        // console.log(mutations);
         for (var k = 0; k < mutations.length; k++) {
           check.call(mutations[k].target, mutations[k]);
         }


### PR DESCRIPTION
Using this on a site to monitor changes to a somewhat frequently changing data attribute and it's dumping tons of things to the console.

This pull request just comments out that stray console.log.
